### PR TITLE
Add an attribute to control default action in attribute driven recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,4 +76,11 @@ default['kernel_modules']['modules_load.d'] = value_for_platform_family(
 # Modules loading options requirements
 default['kernel_modules']['modprobe.d'] = '/etc/modprobe.d'
 
+##
+# Attribute driven attributes
+##
+
+# Allow to define kernel_module resources via attributes
 default['kernel_modules']['modules'] = {}
+# Allow to override the default kernel_module action for the attribute driven resources
+default['kernel_modules']['default_module_action'] = 'load'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 
 node['kernel_modules']['modules'].each do |module_name, property|
   kernel_module module_name do
+    action node['kernel_modules']['default_module_action'] unless property&.key?('action')
     property&.each do |k, v|
       send(k.to_sym, v)
     end


### PR DESCRIPTION
The kernel_modules.modules attribute allows to drive the default recipe
and configure/load/unload modules.
If you do not set an "action" the resource will be run the default one,
which is ":load".
With the new kernel_modules.default_module.action attribute, you can
change the default action for all modules handled in the attribute
driven recipe.