### PR TITLE
Support every release of chef v17 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ Configure and Load kernel modules.
 '
 issues_url       'https://github.com/criteo-cookbooks/kernel-modules/issues' if respond_to?(:issues_url)
 source_url       'https://github.com/criteo-cookbooks/kernel-modules' if respond_to?(:source_url)
-version          '2.1.0'
+version          '2.1.1'
 supports         'redhat', '>= 6.0'
 supports         'centos', '>= 6.0'
 supports         'ubuntu'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,4 +12,4 @@ version          '2.1.0'
 supports         'redhat', '>= 6.0'
 supports         'centos', '>= 6.0'
 supports         'ubuntu'
-chef_version     '>= 17.10' if respond_to?(:chef_version)
+chef_version     '>= 17.0' if respond_to?(:chef_version)


### PR DESCRIPTION
There was no particular reason to accept only very recent versions