### PR TITLE
Fix alias directive using wrong keyword when alias is an Array

### DIFF
--- a/templates/default/modprobe.conf.erb
+++ b/templates/default/modprobe.conf.erb
@@ -6,7 +6,7 @@
      when String -%>
 <%= 'alias ' + [@alias, @name].join(' ') %>
 <%   when Array  -%>
-<%= @alias.sort.map { |v| "options #{v} #{@name}" }.join("\n") %>
+<%= @alias.sort.map { |v| "alias #{v} #{@name}" }.join("\n") %>
 <%   end -%>
 <%   if @install %>
 <%= 'install ' + [@name, @install].join(' ') %>


### PR DESCRIPTION
Looks like a typo — the Array case for `alias` was generating `options` 
directives instead of `alias`. Probably never hit in practice since most 
usages pass `alias` as a String.